### PR TITLE
Typo: Remove `--save` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Node.js v16 or later.
 
 > **Warning** Work in progress. Package can be installed directly from this repository.
 
-`npm install paulrobertlloyd/markdown-it-social-mention --save`
+`npm install paulrobertlloyd/markdown-it-social-mention`
 
 ## Usage
 


### PR DESCRIPTION
The `--save` flag is not needed anymore since v5
https://dev.to/dailydevtips1/you-don-t-need-save-anymore-for-npm-installs-4min